### PR TITLE
fix(activateWifi): Activated wifi is empty when wifi name is not same with ssid.

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -280,6 +280,7 @@ private:
     long int end_rcv_rates = 0;	//保存结束时的流量计数
     long int start_tx_rates = 0;   //保存开始时的流量计数
     long int end_tx_rates = 0; //保存结束时的流量计数
+    QString actWifissid = "--"; //当前连接wifi的ssid
 
 private slots:
     void iconActivated(QSystemTrayIcon::ActivationReason reason);


### PR DESCRIPTION
Log: 修复wifi名称与ssid不对应时，已连接wifi显示为空的bug
Bug: http://172.17.66.192/biz/bug-view-26355.html