### PR TITLE
fix(wpa-wifi): PwdFlag in wpa-dialog is not sync with network manager

### DIFF
--- a/src/oneconnform.cpp
+++ b/src/oneconnform.cpp
@@ -713,6 +713,7 @@ void OneConnForm::on_btnInfo_clicked()
 // Wifi连接结果，0成功 1失败 2没有配置文件
 void OneConnForm::slotConnWifiResult(int connFlag)
 {
+    mw->is_stop_check_net_state = 0;
     qDebug()<<"Function slotConnWifiResult receives a number: "<<connFlag;
 
     if (!connType.isEmpty()) {
@@ -743,12 +744,12 @@ void OneConnForm::slotConnWifiResult(int connFlag)
         ui->btnConnPWD->show();
 
         this->isSelected = true;
-        if (connFlag == 2) {
-            mw->is_stop_check_net_state = 0;
-        } else {
-            mw->is_stop_check_net_state = 0;
-            //connType = "RequestPassword";
-        }
+//        if (connFlag == 2) {
+//            mw->is_stop_check_net_state = 0;
+//        } else {
+//            mw->is_stop_check_net_state = 0;
+//            //connType = "RequestPassword";
+//        }
 
         //设置输入密码框被选中
         ui->lePassword->setFocus();
@@ -770,7 +771,7 @@ void OneConnForm::slotConnWifiResult(int connFlag)
             syslog(LOG_ERR, "execute 'nmcli connection delete' in function 'slotConnWifiResult' failed");
         }
 
-        mw->is_stop_check_net_state = 0;
+//        mw->is_stop_check_net_state = 0;
     }
 
     // 设置全局变量，当前连接Wifi的信号强度

--- a/src/wpawifidialog.h
+++ b/src/wpawifidialog.h
@@ -43,12 +43,14 @@ class UpConnThread : public QThread
     Q_OBJECT
 
 public:
-    explicit UpConnThread();
+    explicit UpConnThread(const QString &, const QString &);
     ~UpConnThread();
 
 public:
     void run();
     QString conn_name = 0;
+    QString m_user = 0;
+    QString m_pwd = 0;
 
 Q_SIGNALS:
     void connRes(int respond);
@@ -67,11 +69,15 @@ private:
     void initUI(); //初始化UI界面
     void initCombox(); //初始化所有下拉框
     void initConnect(); //初始化连接
+    void getPwdFlag(); //获取是否每次询问密码
+    bool setPwdFlag(const int&); //设置是否每次询问密码
 
 protected:
     void paintEvent(QPaintEvent *event);
 
 private:
+    int pwd_flag = 2; //是否每次询问密码，0保存密码，2询问，默认不保存密码
+
     QString connectionName;
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);


### PR DESCRIPTION
Description: 修复是否询问密码设置与NetwordManager不互通的bug
                    修复连接企业wifi显示未提供密码的bug
Bug: http://172.17.66.192/biz/bug-view-27649.html
http://172.17.66.192/biz/bug-view-31120.html