### PR TITLE
fix(wifi): Wifi can not be connected when psk-flag is 1.

### DIFF
--- a/src/backthread.cpp
+++ b/src/backthread.cpp
@@ -329,6 +329,12 @@ void BackThread::execConnWifiPWD(QString connName, QString password, QString con
     emit btFinish();
 }
 
+void BackThread::execConnWifiPsk(QString cmd)
+{
+    int res = Utils::m_system(cmd.toUtf8().data());
+    emit connDone(res);
+}
+
 //to connected wireless network driectly do not need a password
 void BackThread::execConnWifi(QString connName)
 {

--- a/src/backthread.h
+++ b/src/backthread.h
@@ -61,6 +61,7 @@ public slots:
     void execConnLan(QString connName, QString ifname, QString connectType);
     void execConnWifi(QString connName);
     void execConnWifiPWD(QString connName, QString password, QString connType);
+    void execConnWifiPsk(QString cmd);
 
     void disConnSparedNetSlot(QString type);
     void disConnLanOrWifi(QString type);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -190,6 +190,8 @@ public slots:
     void on_btnHotspotState();
     void on_btnWifiList_clicked();
 
+    void connWifiDone(int connFlag);
+
     //flag =0或1为普通点击、2为收到打开信息、3为收到关闭信息、4为无线网卡插入、5为无线网卡拔出
     void onBtnWifiClicked(int flag = 0);
 
@@ -328,7 +330,7 @@ private slots:
     void disWifiStateKeep();
     void disWifiDoneChangeUI();
     void connLanDone(int connFlag);
-    void connWifiDone(int connFlag);
+//    void connWifiDone(int connFlag);
 
     void iconStep();
     void on_btnFlyMode_clicked();

--- a/src/oneconnform.h
+++ b/src/oneconnform.h
@@ -128,6 +128,7 @@ private:
     int waitPage;
     int countCurrentTime;
     bool isWaiting = false;
+    int psk_flag = 0; //密码存储策略
 
     Ui::OneConnForm *ui = nullptr;
     MainWindow *mw = nullptr;
@@ -147,6 +148,7 @@ signals:
 
     void sigConnWifi(QString);
     void sigConnWifiPWD(QString, QString, QString);
+    void sigConnWifiPsk(QString);
 };
 
 #endif // ONECONNFORM_H


### PR DESCRIPTION
Log: 修复wifi密码策略为当前用户存储时连接失败的bug
Bug: http://172.17.66.192/biz/bug-view-31154.html