### PR TITLE
fix(ipv6): Set ipv6.address failed & lan will not reconnect after set successfully.

### DIFF
--- a/src/confform.cpp
+++ b/src/confform.cpp
@@ -253,11 +253,22 @@ void ConfForm::on_btnCreate_clicked()
         kylindbus.showDesktopNotify(txt);
     }
 
+    QString name = ui->leName->text();
+    QStringList charToEscape;
+    charToEscape << "~" << "(" << ")" << "<" << ">" <<"\\" << "*" << "|" << "&" << "#";  //一些命令行特殊字符，需要转义
+    foreach (auto ch , charToEscape) {
+        if (name.contains(ch)) {
+            name.replace(ch, QString("%1%2").arg("\\").arg(ch));
+        }
+    }
+    if (name.contains(" ")) { //空格会影响命令行参数的判断，需要转义
+        name.replace(QRegExp("[\\s]"), "\\\ ");
+    }
     if (!ui->leAddr_ipv6->text().isEmpty()) {
-        QString cmdStr = "nmcli connection modify " + ui->leName->text() + " ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
+        QString cmdStr = "nmcli connection modify " + name + " ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
         Utils::m_system(cmdStr.toUtf8().data());
     } else {
-        QString cmdStr = "nmcli connection modify " + ui->leName->text() + " ipv6.method auto";
+        QString cmdStr = "nmcli connection modify " + name + " ipv6.method auto";
         Utils::m_system(cmdStr.toUtf8().data());
     }
 
@@ -351,15 +362,15 @@ void ConfForm::on_btnSave_clicked()
     }
 
     if (ui->cbType->currentIndex() == 1) {
+        //对于已保存连接修改ipv6地址，使用UUID区分各网络配置（排除名称含空格或特殊字符的干扰）
         if (!ui->leAddr_ipv6->text().isEmpty()) {
-            QString cmdStr = "nmcli connection modify " + ui->leName->text() + " ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
+            QString cmdStr = "nmcli connection modify " + netUuid + " ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
             Utils::m_system(cmdStr.toUtf8().data());
         } else {
-            QString cmdStr = "nmcli connection modify " + ui->leName->text() + " ipv6.method auto";
+            QString cmdStr = "nmcli connection modify " + netUuid + " ipv6.method auto";
             Utils::m_system(cmdStr.toUtf8().data());
         }
     }
-
     QString txt(tr("New network settings already finished"));
     kylindbus.showDesktopNotify(txt);
 }

--- a/src/kylin-dbus-interface.cpp
+++ b/src/kylin-dbus-interface.cpp
@@ -369,6 +369,8 @@ void KylinDBus::getLanIpDNS(QString uuidName, bool isActNet)
                                             dbusArg2nd.endArray();
 
                                             dbusLanIpv6 = m_map.value("address").toString();
+                                        } else if (inner_key == "method") {
+                                            dbusLanIpv6Method = innerMap.value(inner_key).toString();
                                         }
                                     }
                                 }

--- a/src/kylin-dbus-interface.h
+++ b/src/kylin-dbus-interface.h
@@ -88,6 +88,7 @@ public:
 
     QString dbusLanIpv4 = "";
     QString dbusLanIpv6 = "";
+    QString dbusLanIpv6Method = "";
     QString dbusActiveLanIpv4 = "";
     QString dbusActiveLanIpv6 = "";
     QString dbusLanGateway = "";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1604,6 +1604,9 @@ void MainWindow::getLanListDone(QStringList slist)
                             } else if ((oldActLanName == actLanSsidName.at(kk)) && (oldDbusActLanDNS != objKyDBus->dbusActLanDNS)) {
                                 //在第三方nm-connection-editor进行新的DNS配置后，重新连接网络
                                 objKyDBus->reConnectWiredNet(nuuid);
+                            } else if (!objKyDBus->dbusActiveLanIpv6.isEmpty() && objKyDBus->dbusActiveLanIpv6 != objKyDBus->dbusLanIpv6 && objKyDBus->dbusLanIpv6Method == "manual") {
+                                //在第三方nm-connection-editor或kylin-nm配置页进行新的IPV6配置后，重新连接网络
+                                objKyDBus->reConnectWiredNet(nuuid);
                             }
                         }
 


### PR DESCRIPTION
Log: 修复名称含空格的有线网设置ipv6地址不生效的问题，和ipv6设置后不自动重连的问题
Bug: http://172.17.66.192/biz/bug-view-38287.html