### PR TITLE
Fix:Unescape characters to avoid bugs.

### DIFF
--- a/src/confform.cpp
+++ b/src/confform.cpp
@@ -292,14 +292,11 @@ void ConfForm::on_btnCreate_clicked()
             name.replace(ch, QString("%1%2").arg("\\").arg(ch));
         }
     }
-    if (name.contains(" ")) { //空格会影响命令行参数的判断，需要转义
-        name.replace(QRegExp("[\\s]"), "\\\ ");
-    }
     if (!ui->leAddr_ipv6->text().isEmpty()) {
-        QString cmdStr = "nmcli connection modify " + name + " ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
+        QString cmdStr = "nmcli connection modify '" + name + "' ipv6.method manual ipv6.addresses " + ui->leAddr_ipv6->text();
         Utils::m_system(cmdStr.toUtf8().data());
     } else {
-        QString cmdStr = "nmcli connection modify " + name + " ipv6.method auto";
+        QString cmdStr = "nmcli connection modify '" + name + "' ipv6.method auto";
         Utils::m_system(cmdStr.toUtf8().data());
     }
 

--- a/src/oneconnform.cpp
+++ b/src/oneconnform.cpp
@@ -605,11 +605,7 @@ void OneConnForm::toConnectWirelessNetwork()
     if (isWifiConfExist(wifiName)) {
         //有配置文件，获取密码存储策略
         QProcess * process = new QProcess(this);
-        QString ssid = wifiName;
-        if (ssid.contains(" ")) {
-            ssid.replace(QRegExp("[\\s]"), "\\\ "); //防止名字包含空格导致指令识别错误，需要转义
-        }
-        process->start(QString("nmcli -f 802-11-wireless-security.psk-flags connection show %1").arg(wifiName));
+        process->start(QString("nmcli -f 802-11-wireless-security.psk-flags connection show \"%1\"").arg(wifiName));
         connect(process, static_cast<void(QProcess::*)(int,QProcess::ExitStatus)>(&QProcess::finished), this, [ = ]() {
             process->deleteLater();
         });
@@ -1027,11 +1023,7 @@ void OneConnForm::on_btnCancel_clicked()
 int OneConnForm::getPskFlag()
 {
     QProcess * process = new QProcess(this);
-    QString ssid = wifiName;
-    if (ssid.contains(" ")) {
-        ssid.replace(QRegExp("[\\s]"), "\\\ "); //防止名字包含空格导致指令识别错误，需要转义
-    }
-    process->start(QString("nmcli -f 802-11-wireless-security.psk-flags connection show %1").arg(wifiName));
+    process->start(QString("nmcli -f 802-11-wireless-security.psk-flags connection show \"%1\"").arg(wifiName));
     connect(process, static_cast<void(QProcess::*)(int,QProcess::ExitStatus)>(&QProcess::finished), this, [ = ]() {
         process->deleteLater();
     });


### PR DESCRIPTION
取消字符转义，通过单(util)、双(qprocess)引号分隔网络名称参数来避免传值错误的问题