### PR TITLE
Fix: Wifi icon in panel is not same with activated wifi.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -936,6 +936,7 @@ void MainWindow::getActiveInfoAndSetTrayIcon()
 
     } else if (actWifiName != "--") {
         setTrayIconOfWifi(activeWifiSignalLv);
+        emit this->actWifiSignalLvChanaged(activeWifiSignalLv);
     } else {
         setTrayIcon(iconLanOffline);
     }
@@ -2187,6 +2188,9 @@ void MainWindow::loadWifiListDone(QStringList slist)
             //qDebug() << "wifi的 bssid: " << wbssid << "当前连接的wifi的bssid: " << actWifiBssidList;
             if(actWifiBssid == wbssid && wifiActState == 2){
                 //对于已经连接的wifi
+                connect(this, &MainWindow::actWifiSignalLvChanaged, ccf, [ = ](const int &signalLv) {
+                    ccf->setSignal(QString::number(signalLv), wsecu);
+                });
                 connect(ccf, SIGNAL(selectedOneWifiForm(QString,int)), this, SLOT(oneTopWifiFormSelected(QString,int)));
                 connect(ccf, SIGNAL(disconnActiveWifi()), this, SLOT(activeWifiDisconn()));
                 QString path = line.mid(indexPath).trimmed();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -401,6 +401,7 @@ signals:
     void waitWifiStop();
     void waitLanStop();
     void reConnectWifi(const QString& uuid);
+    void actWifiSignalLvChanaged(const int& currentLevel);
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
修复任务栏和网络列表中已连接网络显示的信号强度不一致的bug
http://172.17.66.192/biz/bug-view-46040.html