### PR TITLE
改为通过DBUS接口获取SSID

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2371,14 +2371,15 @@ void MainWindow::loadWifiListDone(QStringList slist)
     for (int i = 1; i < slist.size(); i ++) {
         QString line = slist.at(i);
         QString wbssid = line.mid(indexBSsid, 17).trimmed();
-        QString wname = line.mid(indexName, indexPath - indexName).trimmed();
-        int chineseNum = 0;
-        for(QChar text:wname){
-            if(text.unicode() > 0x4E00 && text.unicode() <= 0x9FFF){//统计字符串中中文字符的个数
-                chineseNum++;
-            }
-        }
-        wname = line.mid(indexName, indexPath - indexName - chineseNum).trimmed();
+        int Path = line.indexOf("/org/");
+        QString wDbusPath = line.mid(Path, indexCate-indexPath).trimmed();
+        QDBusInterface interface("org.freedesktop.NetworkManager",
+                                  wDbusPath,
+                                  "org.freedesktop.DBus.Properties",
+                                  QDBusConnection::systemBus() );
+        QDBusReply<QVariant> reply = interface.call("Get","org.freedesktop.NetworkManager.AccessPoint","Ssid");
+        QString wname = reply.value().toString();
+
         if (actWifiBssidList.contains(wbssid)) {
             actWifiName = wname;
         }
@@ -2397,16 +2398,16 @@ void MainWindow::loadWifiListDone(QStringList slist)
         QString wsignal = line.mid(indexSignal, 3).trimmed();
         QString wsecu = line.mid(indexSecu, indexFreq - indexSecu).trimmed();
         QString wbssid = line.mid(indexBSsid, 17).trimmed();
-        QString wname = line.mid(indexName, indexPath - indexName).trimmed();
         QString wfreq = line.mid(indexFreq, 4).trimmed();
         QString wcate = line.mid(indexCate).trimmed();
-        int chineseNum = 0;
-        for(QChar text:wname){
-            if(text.unicode() > 0x4E00 && text.unicode() <= 0x9FFF){//统计字符串中中文字符的个数
-                chineseNum++;
-            }
-        }
-        wname = line.mid(indexName, indexPath - indexName - chineseNum).trimmed();
+        int Path = line.indexOf("/org/");
+        QString wDbusPath = line.mid(Path, indexCate-indexPath).trimmed();
+        QDBusInterface interface("org.freedesktop.NetworkManager",
+                                  wDbusPath,
+                                  "org.freedesktop.DBus.Properties",
+                                  QDBusConnection::systemBus() );
+        QDBusReply<QVariant> reply = interface.call("Get","org.freedesktop.NetworkManager.AccessPoint","Ssid");
+        QString wname = reply.value().toString();
 
         if (!isHuaWeiPC) {
             //如果不是华为的电脑，选择wifi在这里执行
@@ -2432,14 +2433,15 @@ void MainWindow::loadWifiListDone(QStringList slist)
         int max_freq = wfreq.toInt();
         int min_freq = wfreq.toInt();
         for (int k = i; k < slist.size(); k ++) {
-            QString m_name = slist.at(k).mid(indexName, indexPath - indexName).trimmed();
-            int chineseNum = 0;
-            for(QChar text:wname){
-                if(text.unicode() > 0x4E00 && text.unicode() <= 0x9FFF){//统计字符串中中文字符的个数
-                    chineseNum++;
-                }
-            }
-            wname = line.mid(indexName, indexPath - indexName - chineseNum).trimmed();
+            QString tmpLine = slist.at(k);
+            int Path = tmpLine.indexOf("/org/");
+            QString m_DbusPath = slist.at(k).mid(Path, indexCate-indexPath).trimmed();
+            QDBusInterface m_interface("org.freedesktop.NetworkManager",
+                                    wDbusPath,
+                                    "org.freedesktop.DBus.Properties",
+                                    QDBusConnection::systemBus() );
+            QDBusReply<QVariant> m_reply = m_interface.call("Get","org.freedesktop.NetworkManager.AccessPoint","Ssid");
+            QString m_name = m_reply.value().toString();
 
             if (wname == m_name) {
                 if (slist.at(k).mid(indexFreq, 4).trimmed().toInt() > max_freq) {


### PR DESCRIPTION
FIX:通过DBUS获取SSID， 避免ssid存在空格时，识别错误的问题
LINK:BUG53732